### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TEAM07
 
-This is the repository for the team 07 of the course CS 308 - Software Engineering at the Sabanci University.
+This is the repository for the team 07 of the course CS 308 - Software Engineering at Sabanci University.
 
 We will develope an online store to sell our own brand of coffee.
 


### PR DESCRIPTION
Sabanci University is a noun. Usage of "the" before a noun is a grammatical mistake with artical usage.