### PR TITLE
fix(guide): update .env configuration in development guide

### DIFF
--- a/PROJECT_DEVELOPMENT_GUIDE.md
+++ b/PROJECT_DEVELOPMENT_GUIDE.md
@@ -47,6 +47,7 @@ If you need more detailed instructions, refer to the sections below.
      DB_PASS=
      DB_NAME=ecommerce_db
      ```
+     The `DB_PASS` field should be left empty since for now during the development phase, the database is modified to accepts empty passwords.
 
 ### 2. Start Services with Docker
 
@@ -340,6 +341,7 @@ To ensure consistency and eliminate environment-related issues across all team m
      DB_PASS=
      DB_NAME=ecommerce_db
      ```
+  The `DB_PASS` field should be left empty since for now during the development phase, the database is modified to accepts empty passwords.
 
 4. **Setup Docker with `docker-compose`:**
    - In the project root directory, create a `docker-compose.yml` file to define the services (backend, frontend, and MySQL database):


### PR DESCRIPTION
During the development phase we are not using password for the database, so I modified  the `.env` file in the guide accordingly to reflect this.